### PR TITLE
Created deep copy implementation through copy constructor for DataModel classes

### DIFF
--- a/Project/NetworkModelService/DataModel/Core/AsynchronousMachine.cs
+++ b/Project/NetworkModelService/DataModel/Core/AsynchronousMachine.cs
@@ -1,36 +1,38 @@
 ﻿using FTN.Common;
 using FTN.Services.NetworkModelService.DataModel.Wires;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Core
 {
     public class AsynchronousMachine : RegulatingCondEq
     {
+        public float CosPhi { get; set; }
+
+        public float CurrentTemp { get; set; }
+
+        public float MaximumTemp { get; set; }
+
+        public float MinimumTemp { get; set; }
+
+        public float RatedP { get; set; }
+
         public AsynchronousMachine(long gID) : base(gID)
         {
         }
-
-        private float cosPhi;
-        private float ratedP;
-        private float minimumTemp;
-        private float maximumTemp;
-        private float currentTemp;
-
-        public float CosPhi { get => cosPhi; set => cosPhi = value; }
-        public float RatedP { get => ratedP; set => ratedP = value; }
-        public float MinimumTemp { get => minimumTemp; set => minimumTemp = value; }
-        public float MaximumTemp { get => maximumTemp; set => maximumTemp = value; }
-        public float CurrentTemp { get => currentTemp; set => currentTemp = value; }
+        public AsynchronousMachine(AsynchronousMachine machine) : base(machine)
+        {
+            CosPhi = machine.CosPhi;
+            CurrentTemp = machine.CurrentTemp;
+            MaximumTemp = machine.MaximumTemp;
+            MinimumTemp = machine.MinimumTemp;
+            RatedP = machine.RatedP;
+        }
 
         public override bool Equals(object obj)
         {
             if (base.Equals(obj))
             {
                 AsynchronousMachine x = (AsynchronousMachine)obj;
-                return ((x.cosPhi == this.cosPhi) && (x.ratedP == this.ratedP) && (x.currentTemp==this.currentTemp) && (x.minimumTemp == this.minimumTemp) && (x.maximumTemp == this.maximumTemp));
+                return ((x.CosPhi == this.CosPhi) && (x.RatedP == this.RatedP) && (x.CurrentTemp == this.CurrentTemp) && (x.MinimumTemp == this.MinimumTemp) && (x.MaximumTemp == this.MaximumTemp));
             }
             else
             {
@@ -44,6 +46,31 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
         }
 
         #region IAccess
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.ASYNCMACHINE_COSPHI:
+                    property.SetValue(CosPhi);
+                    break;
+                case ModelCode.ASYNCMACHINE_RATEDP:
+                    property.SetValue(RatedP);
+                    break;
+                case ModelCode.ASYNCMACHINE_CURRTEMP:
+                    property.SetValue(CurrentTemp);
+                    break;
+                case ModelCode.ASYNCMACHINE_MINTEMP:
+                    property.SetValue(MinimumTemp);
+                    break;
+                case ModelCode.ASYNCMACHINE_MAXTEMP:
+                    property.SetValue(MaximumTemp);
+                    break;
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -59,48 +86,24 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     return base.HasProperty(property);
             }
         }
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.ASYNCMACHINE_COSPHI:
-                    property.SetValue(cosPhi);
-                    break;
-                case ModelCode.ASYNCMACHINE_RATEDP:
-                    property.SetValue(ratedP);
-                    break;
-                case ModelCode.ASYNCMACHINE_CURRTEMP:
-                    property.SetValue(currentTemp);
-                    break;
-                case ModelCode.ASYNCMACHINE_MINTEMP:
-                    property.SetValue(minimumTemp);
-                    break;
-                case ModelCode.ASYNCMACHINE_MAXTEMP:
-                    property.SetValue(maximumTemp);
-                    break;
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.ASYNCMACHINE_COSPHI:
-                    cosPhi = property.AsFloat();
+                    CosPhi = property.AsFloat();
                     break;
                 case ModelCode.ASYNCMACHINE_RATEDP:
-                    ratedP = property.AsFloat();
+                    RatedP = property.AsFloat();
                     break;
                 case ModelCode.ASYNCMACHINE_CURRTEMP:
-                    currentTemp = property.AsFloat();
+                    CurrentTemp = property.AsFloat();
                     break;
                 case ModelCode.ASYNCMACHINE_MINTEMP:
-                    minimumTemp = property.AsFloat();
+                    MinimumTemp = property.AsFloat();
                     break;
                 case ModelCode.ASYNCMACHINE_MAXTEMP:
-                    maximumTemp = property.AsFloat();
+                    MaximumTemp = property.AsFloat();
                     break;
 
                 default:

--- a/Project/NetworkModelService/DataModel/Core/ConductingEquipment.cs
+++ b/Project/NetworkModelService/DataModel/Core/ConductingEquipment.cs
@@ -1,31 +1,26 @@
-﻿using System;
+﻿using FTN.Common;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Xml;
-using FTN.Common;
 
 namespace FTN.Services.NetworkModelService.DataModel.Core
 {
-	public class ConductingEquipment : Equipment
-	{
+    public class ConductingEquipment : Equipment
+    {
+        public List<long> Terminals { get; set; } = new List<long>();
+
         public ConductingEquipment(long gID) : base(gID)
         {
         }
-
-        private List<long> terminals = new List<long>();
-
-        public List<long> Terminals { get => terminals; set => terminals = value; }
-
+        public ConductingEquipment(ConductingEquipment equipment) : base(equipment)
+        {
+            Terminals = new List<long>(equipment.Terminals);
+        }
 
         public override bool Equals(object x)
         {
             if (base.Equals(x))
             {
                 ConductingEquipment c = (ConductingEquipment)x;
-                return CompareHelper.CompareLists(c.terminals, this.terminals);
+                return CompareHelper.CompareLists(c.Terminals, this.Terminals);
             }
             else
             {
@@ -40,6 +35,20 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
 
         #region IAccess implementation	
 
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.CONDEQ_TERMINALS:
+                    property.SetValue(Terminals);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -51,21 +60,6 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.CONDEQ_TERMINALS:
-                    property.SetValue(terminals);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             base.SetProperty(property);
@@ -79,18 +73,8 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
         {
             get
             {
-                return terminals.Count != 0 || base.IsReferenced;
+                return Terminals.Count != 0 || base.IsReferenced;
             }
-        }
-
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-            if (terminals != null && terminals.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.CONDEQ_TERMINALS] = terminals.GetRange(0, terminals.Count);
-            }
-
-            base.GetReferences(references, refType);
         }
 
         public override void AddReference(ModelCode referenceId, long globalId)
@@ -98,7 +82,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             switch (referenceId)
             {
                 case ModelCode.TERMINAL_CONDEQUIPMENT:
-                    terminals.Add(globalId);
+                    Terminals.Add(globalId);
                     break;
 
                 default:
@@ -107,15 +91,24 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             }
         }
 
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+            if (Terminals != null && Terminals.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.CONDEQ_TERMINALS] = Terminals.GetRange(0, Terminals.Count);
+            }
+
+            base.GetReferences(references, refType);
+        }
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.TERMINAL_CONDEQUIPMENT:
 
-                    if (terminals.Contains(globalId))
+                    if (Terminals.Contains(globalId))
                     {
-                        terminals.Remove(globalId);
+                        Terminals.Remove(globalId);
                     }
                     else
                     {

--- a/Project/NetworkModelService/DataModel/Core/ConnectivityNodeContainer.cs
+++ b/Project/NetworkModelService/DataModel/Core/ConnectivityNodeContainer.cs
@@ -1,27 +1,26 @@
 ﻿using FTN.Common;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Core
 {
     public class ConnectivityNodeContainer : PowerSystemResource
     {
+        public List<long> ConnectivityNodes { get; set; } = new List<long>();
+
         public ConnectivityNodeContainer(long gID) : base(gID)
         {
         }
-
-        private List<long> connectivityNodes = new List<long>();
-
-        public List<long> ConnectivityNodes { get => connectivityNodes; set => connectivityNodes = value; }
+        public ConnectivityNodeContainer(ConnectivityNodeContainer container) : base(container)
+        {
+            ConnectivityNodes = new List<long>(container.ConnectivityNodes);
+        }
 
         public override bool Equals(object x)
         {
             if (base.Equals(x))
             {
                 ConnectivityNodeContainer c = (ConnectivityNodeContainer)x;
-                return CompareHelper.CompareLists(c.connectivityNodes, this.connectivityNodes);
+                return CompareHelper.CompareLists(c.ConnectivityNodes, this.ConnectivityNodes);
             }
             else
             {
@@ -36,6 +35,20 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
 
         #region IAccess implementation	
 
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.CONNNODECONTAINER_CONNNODES:
+                    property.SetValue(ConnectivityNodes);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -47,21 +60,6 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.CONNNODECONTAINER_CONNNODES:
-                    property.SetValue(connectivityNodes);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             base.SetProperty(property);
@@ -75,18 +73,8 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
         {
             get
             {
-                return connectivityNodes.Count > 0 || base.IsReferenced;
+                return ConnectivityNodes.Count > 0 || base.IsReferenced;
             }
-        }
-
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-            if (connectivityNodes != null && connectivityNodes.Count > 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.CONNNODECONTAINER_CONNNODES] = connectivityNodes.GetRange(0, connectivityNodes.Count);
-            }
-
-            base.GetReferences(references, refType);
         }
 
         public override void AddReference(ModelCode referenceId, long globalId)
@@ -94,7 +82,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             switch (referenceId)
             {
                 case ModelCode.CONNECTIVITYNODE_CNODECONT:
-                    connectivityNodes.Add(globalId);
+                    ConnectivityNodes.Add(globalId);
                     break;
 
                 default:
@@ -103,15 +91,24 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             }
         }
 
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+            if (ConnectivityNodes != null && ConnectivityNodes.Count > 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.CONNNODECONTAINER_CONNNODES] = ConnectivityNodes.GetRange(0, ConnectivityNodes.Count);
+            }
+
+            base.GetReferences(references, refType);
+        }
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.CONNECTIVITYNODE_CNODECONT:
 
-                    if (connectivityNodes.Contains(globalId))
+                    if (ConnectivityNodes.Contains(globalId))
                     {
-                        connectivityNodes.Remove(globalId);
+                        ConnectivityNodes.Remove(globalId);
                     }
                     else
                     {

--- a/Project/NetworkModelService/DataModel/Core/Equipment.cs
+++ b/Project/NetworkModelService/DataModel/Core/Equipment.cs
@@ -1,30 +1,27 @@
-﻿using System;
+﻿using FTN.Common;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Xml;
-using FTN.Common;
 
 namespace FTN.Services.NetworkModelService.DataModel.Core
 {
-	public class Equipment : PowerSystemResource
-	{
+    public class Equipment : PowerSystemResource
+    {
+        public long EquipmentContainer { get; set; } = 0;
+
         public Equipment(long gID) : base(gID)
         {
         }
 
-        private long equipmentContainer = 0;
-
-        public long EquipmentContainer { get => equipmentContainer; set => equipmentContainer = value; }
+        public Equipment(Equipment equipment) : base(equipment)
+        {
+            EquipmentContainer = equipment.EquipmentContainer;
+        }
 
         public override bool Equals(object x)
         {
             if (base.Equals(x))
             {
                 Equipment e = (Equipment)x;
-                return e.equipmentContainer == this.equipmentContainer;
+                return e.EquipmentContainer == this.EquipmentContainer;
             }
             else
             {
@@ -39,6 +36,20 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
 
         #region IAccess implementation	
 
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.EQUIPMENT_EQUIPCONTAINER:
+                    property.SetValue(EquipmentContainer);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -50,27 +61,12 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.EQUIPMENT_EQUIPCONTAINER:
-                    property.SetValue(equipmentContainer);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.EQUIPMENT_EQUIPCONTAINER:
-                    equipmentContainer = property.AsReference();
+                    EquipmentContainer = property.AsReference();
                     break;
 
                 default:
@@ -85,11 +81,11 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
 
         public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
         {
-            if (equipmentContainer != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            if (EquipmentContainer != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
             {
                 references[ModelCode.EQUIPMENT_EQUIPCONTAINER] = new List<long>
                 {
-                    equipmentContainer
+                    EquipmentContainer
                 };
             }
 

--- a/Project/NetworkModelService/DataModel/Core/EquipmentContainer.cs
+++ b/Project/NetworkModelService/DataModel/Core/EquipmentContainer.cs
@@ -1,28 +1,26 @@
 ﻿using FTN.Common;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Core
 {
     public class EquipmentContainer : ConnectivityNodeContainer
     {
+        public List<long> Equipments { get; set; } = new List<long>();
+
         public EquipmentContainer(long gID) : base(gID)
         {
         }
-
-        private List<long> equipments = new List<long>();
-
-        public List<long> Equipments { get => equipments; set => equipments = value; }
-
+        public EquipmentContainer(EquipmentContainer container) : base(container)
+        {
+            Equipments = new List<long>(container.Equipments);
+        }
 
         public override bool Equals(object x)
         {
             if (base.Equals(x))
             {
                 EquipmentContainer ec = (EquipmentContainer)x;
-                return CompareHelper.CompareLists(ec.equipments, this.equipments);
+                return CompareHelper.CompareLists(ec.Equipments, this.Equipments);
             }
             else
             {
@@ -37,6 +35,20 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
 
         #region IAccess implementation	
 
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.EQUIPMENTCONTAINER_EQUIPS:
+                    property.SetValue(Equipments);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -48,21 +60,6 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.EQUIPMENTCONTAINER_EQUIPS:
-                    property.SetValue(equipments);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             base.SetProperty(property);
@@ -76,18 +73,8 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
         {
             get
             {
-                return equipments.Count != 0 || base.IsReferenced;
+                return Equipments.Count != 0 || base.IsReferenced;
             }
-        }
-
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-            if (equipments != null && equipments.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.EQUIPMENTCONTAINER_EQUIPS] = equipments.GetRange(0, equipments.Count);
-            }
-
-            base.GetReferences(references, refType);
         }
 
         public override void AddReference(ModelCode referenceId, long globalId)
@@ -95,7 +82,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             switch (referenceId)
             {
                 case ModelCode.EQUIPMENT_EQUIPCONTAINER:
-                    equipments.Add(globalId);
+                    Equipments.Add(globalId);
                     break;
 
                 default:
@@ -104,15 +91,24 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             }
         }
 
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+            if (Equipments != null && Equipments.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.EQUIPMENTCONTAINER_EQUIPS] = Equipments.GetRange(0, Equipments.Count);
+            }
+
+            base.GetReferences(references, refType);
+        }
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.EQUIPMENT_EQUIPCONTAINER:
 
-                    if (equipments.Contains(globalId))
+                    if (Equipments.Contains(globalId))
                     {
-                        equipments.Remove(globalId);
+                        Equipments.Remove(globalId);
                     }
                     else
                     {

--- a/Project/NetworkModelService/DataModel/Core/PowerSystemResource.cs
+++ b/Project/NetworkModelService/DataModel/Core/PowerSystemResource.cs
@@ -1,36 +1,37 @@
-﻿using System;
+﻿using FTN.Common;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using FTN.Common;
 
 
 
 namespace FTN.Services.NetworkModelService.DataModel.Core
 {
-	public class PowerSystemResource : IdentifiedObject
-	{
+    public class PowerSystemResource : IdentifiedObject
+    {
+        public List<long> Measurements { get; set; } = new List<long>();
+
         public PowerSystemResource(long gID) : base(gID)
         {
         }
 
-        private List<long> measurements = new List<long>();
-
-        public List<long> Measurements { get => measurements; set => measurements = value; }
-
-        public override bool Equals(object x)
+        public PowerSystemResource(PowerSystemResource resource) : base(resource)
         {
-            return base.Equals(x);
+            Measurements = new List<long>(resource.Measurements);
         }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
-
         #region IAccess implementation
+
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.PSR_MEASUREMENTS:
+                    property.SetValue(Measurements);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
 
         public override bool HasProperty(ModelCode property)
         {
@@ -43,21 +44,6 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.PSR_MEASUREMENTS:
-                    property.SetValue(measurements);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             base.SetProperty(property);
@@ -71,18 +57,8 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
         {
             get
             {
-                return measurements.Count != 0 || base.IsReferenced;
+                return Measurements.Count != 0 || base.IsReferenced;
             }
-        }
-
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-            if (measurements != null && measurements.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.PSR_MEASUREMENTS] = measurements.GetRange(0, measurements.Count);
-            }
-
-            base.GetReferences(references, refType);
         }
 
         public override void AddReference(ModelCode referenceId, long globalId)
@@ -90,7 +66,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             switch (referenceId)
             {
                 case ModelCode.MEASUREMENT_PSR:
-                    measurements.Add(globalId);
+                    Measurements.Add(globalId);
                     break;
 
                 default:
@@ -99,15 +75,24 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             }
         }
 
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+            if (Measurements != null && Measurements.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.PSR_MEASUREMENTS] = Measurements.GetRange(0, Measurements.Count);
+            }
+
+            base.GetReferences(references, refType);
+        }
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.MEASUREMENT_PSR:
 
-                    if (measurements.Contains(globalId))
+                    if (Measurements.Contains(globalId))
                     {
-                        measurements.Remove(globalId);
+                        Measurements.Remove(globalId);
                     }
                     else
                     {
@@ -121,6 +106,8 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     break;
             }
         }
+
+
 
         #endregion
     }

--- a/Project/NetworkModelService/DataModel/Core/Substation.cs
+++ b/Project/NetworkModelService/DataModel/Core/Substation.cs
@@ -1,17 +1,18 @@
 ﻿using FTN.Common;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Core
 {
     public class Substation : EquipmentContainer
     {
-        private int capacity;
-        public int Capacity { get => capacity; set => capacity = value; }
+        public int Capacity { get; set; }
+
         public Substation(long gID) : base(gID)
         {
+        }
+
+        public Substation(Substation substation) : base(substation)
+        {
+            Capacity = substation.Capacity;
         }
 
         public override bool Equals(object x)
@@ -19,7 +20,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             if (base.Equals(x))
             {
                 Substation s = (Substation)x;
-                return this.capacity ==s.Capacity?true:false;
+                return this.Capacity == s.Capacity ? true : false;
             }
             else
             {
@@ -34,6 +35,20 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
 
         #region IAccess implementation	
 
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.SUBSTATION_CAPACITY:
+                    property.SetValue(Capacity);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -45,27 +60,12 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.SUBSTATION_CAPACITY:
-                    property.SetValue(capacity);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.SUBSTATION_CAPACITY:
-                    capacity = property.AsInt();
+                    Capacity = property.AsInt();
                     break;
                 default:
                     base.SetProperty(property);

--- a/Project/NetworkModelService/DataModel/Core/Terminal.cs
+++ b/Project/NetworkModelService/DataModel/Core/Terminal.cs
@@ -1,34 +1,35 @@
 ﻿using FTN.Common;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Core
 {
     public class Terminal : IdentifiedObject
     {
+
+        public long ConductingEquipment { get; set; } = 0;
+
+        public long ConnectivityNode { get; set; } = 0;
+
+        public List<long> Measurements { get; set; } = new List<long>();
+
         public Terminal(long gID) : base(gID)
         {
         }
-
-        private long connectivityNode = 0;
-        private long conductingEquipment = 0;
-        private List<long> measurements = new List<long>();
-
-        public long ConnectivityNode { get => connectivityNode; set => connectivityNode = value; }
-        public long ConductingEquipment { get => conductingEquipment; set => conductingEquipment = value; }
-        public List<long> Measurements { get => measurements; set => measurements = value; }
-
+        public Terminal(Terminal terminal) : base(terminal)
+        {
+            ConductingEquipment = terminal.ConductingEquipment;
+            ConnectivityNode = terminal.ConnectivityNode;
+            Measurements = terminal.Measurements;
+        }
 
         public override bool Equals(object x)
         {
             if (base.Equals(x))
             {
                 Terminal t = (Terminal)x;
-                return (t.conductingEquipment == this.conductingEquipment
-                        && t.connectivityNode == this.connectivityNode
-                        && CompareHelper.CompareLists(t.measurements, this.measurements));
+                return (t.ConductingEquipment == this.ConductingEquipment
+                        && t.ConnectivityNode == this.ConnectivityNode
+                        && CompareHelper.CompareLists(t.Measurements, this.Measurements));
             }
             else
             {
@@ -43,6 +44,26 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
 
         #region IAccess implementation	
 
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.TERMINAL_CONDEQUIPMENT:
+                    property.SetValue(ConductingEquipment);
+                    break;
+                case ModelCode.TERMINAL_CONNNODE:
+                    property.SetValue(ConnectivityNode);
+                    break;
+                case ModelCode.TERMINAL_MEASUREMENTS:
+                    property.SetValue(Measurements);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -56,36 +77,15 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.TERMINAL_CONDEQUIPMENT:
-                    property.SetValue(conductingEquipment);
-                    break;
-                case ModelCode.TERMINAL_CONNNODE:
-                    property.SetValue(connectivityNode);
-                    break;
-                case ModelCode.TERMINAL_MEASUREMENTS:
-                    property.SetValue(measurements);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.TERMINAL_CONDEQUIPMENT:
-                    conductingEquipment = property.AsReference();
+                    ConductingEquipment = property.AsReference();
                     break;
                 case ModelCode.TERMINAL_CONNNODE:
-                    connectivityNode = property.AsReference();
+                    ConnectivityNode = property.AsReference();
                     break;
 
                 default:
@@ -102,32 +102,8 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
         {
             get
             {
-                return measurements.Count != 0 || base.IsReferenced;
+                return Measurements.Count != 0 || base.IsReferenced;
             }
-        }
-
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-            if (conductingEquipment != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.TERMINAL_CONDEQUIPMENT] = new List<long>
-                {
-                    conductingEquipment
-                };
-            }
-            if (connectivityNode != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.TERMINAL_CONNNODE] = new List<long>
-                {
-                    connectivityNode
-                };
-            }
-            if (measurements != null && measurements.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.TERMINAL_MEASUREMENTS] = measurements.GetRange(0, measurements.Count);
-            }
-
-            base.GetReferences(references, refType);
         }
 
         public override void AddReference(ModelCode referenceId, long globalId)
@@ -135,7 +111,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             switch (referenceId)
             {
                 case ModelCode.MEASUREMENT_TERMINAL:
-                    measurements.Add(globalId);
+                    Measurements.Add(globalId);
                     break;
 
                 default:
@@ -144,15 +120,38 @@ namespace FTN.Services.NetworkModelService.DataModel.Core
             }
         }
 
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+            if (ConductingEquipment != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.TERMINAL_CONDEQUIPMENT] = new List<long>
+                {
+                    ConductingEquipment
+                };
+            }
+            if (ConnectivityNode != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.TERMINAL_CONNNODE] = new List<long>
+                {
+                    ConnectivityNode
+                };
+            }
+            if (Measurements != null && Measurements.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.TERMINAL_MEASUREMENTS] = Measurements.GetRange(0, Measurements.Count);
+            }
+
+            base.GetReferences(references, refType);
+        }
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.MEASUREMENT_TERMINAL:
 
-                    if (measurements.Contains(globalId))
+                    if (Measurements.Contains(globalId))
                     {
-                        measurements.Remove(globalId);
+                        Measurements.Remove(globalId);
                     }
                     else
                     {

--- a/Project/NetworkModelService/DataModel/Meas/Analog.cs
+++ b/Project/NetworkModelService/DataModel/Meas/Analog.cs
@@ -1,31 +1,32 @@
 ﻿using FTN.Common;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Meas
 {
     public class Analog : Measurement
     {
+
+        public float MaxValue { get; set; }
+
+        public float MinValue { get; set; }
+
+        public float NormalValue { get; set; }
+
         public Analog(long gID) : base(gID)
         {
         }
-
-        private float maxValue;
-        private float minValue;
-        private float normalValue;
-
-        public float MaxValue { get => maxValue; set => maxValue = value; }
-        public float MinValue { get => minValue; set => minValue = value; }
-        public float NormalValue { get => normalValue; set => normalValue = value; }
+        public Analog(Analog analog) : base(analog)
+        {
+            MaxValue = analog.MaxValue;
+            MinValue = analog.MinValue;
+            NormalValue = analog.NormalValue;
+        }
 
         public override bool Equals(object obj)
         {
             if (base.Equals(obj))
             {
                 Analog x = (Analog)obj;
-                return ((x.maxValue == this.maxValue) && (x.minValue == this.minValue) && (x.normalValue == this.normalValue));
+                return ((x.MaxValue == this.MaxValue) && (x.MinValue == this.MinValue) && (x.NormalValue == this.NormalValue));
             }
             else
             {
@@ -39,6 +40,26 @@ namespace FTN.Services.NetworkModelService.DataModel.Meas
         }
 
         #region IAccess
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.ANALOG_MAXVALUE:
+                    property.SetValue(MaxValue);
+                    break;
+                case ModelCode.ANALOG_MINVALUE:
+                    property.SetValue(MinValue);
+                    break;
+                case ModelCode.ANALOG_NORMALVALUE:
+                    property.SetValue(NormalValue);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -52,37 +73,18 @@ namespace FTN.Services.NetworkModelService.DataModel.Meas
                     return base.HasProperty(property);
             }
         }
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.ANALOG_MAXVALUE:
-                    property.SetValue(maxValue);
-                    break;
-                case ModelCode.ANALOG_MINVALUE:
-                    property.SetValue(minValue);
-                    break;
-                case ModelCode.ANALOG_NORMALVALUE:
-                    property.SetValue(normalValue);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.ANALOG_MAXVALUE:
-                    maxValue = property.AsFloat();
+                    MaxValue = property.AsFloat();
                     break;
                 case ModelCode.ANALOG_MINVALUE:
-                    minValue = property.AsFloat();
+                    MinValue = property.AsFloat();
                     break;
                 case ModelCode.ANALOG_NORMALVALUE:
-                    normalValue = property.AsFloat();
+                    NormalValue = property.AsFloat();
                     break;
 
                 default:

--- a/Project/NetworkModelService/DataModel/Meas/Discrete.cs
+++ b/Project/NetworkModelService/DataModel/Meas/Discrete.cs
@@ -1,31 +1,31 @@
 ﻿using FTN.Common;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Meas
 {
     public class Discrete : Measurement
     {
+        public int MaxValue { get; set; }
+
+        public int MinValue { get; set; }
+
+        public int NormalValue { get; set; }
+
         public Discrete(long gID) : base(gID)
         {
         }
-
-        private int maxValue;
-        private int minValue;
-        private int normalValue;
-
-        public int MaxValue { get => maxValue; set => maxValue = value; }
-        public int MinValue { get => minValue; set => minValue = value; }
-        public int NormalValue { get => normalValue; set => normalValue = value; }
+        public Discrete(Discrete discrete) : base(discrete)
+        {
+            MaxValue = discrete.MaxValue;
+            MinValue = discrete.MinValue;
+            NormalValue = discrete.NormalValue;
+        }
 
         public override bool Equals(object obj)
         {
             if (base.Equals(obj))
             {
                 Discrete x = (Discrete)obj;
-                return ((x.maxValue == this.maxValue) && (x.minValue == this.minValue) && (x.normalValue == this.normalValue));
+                return ((x.MaxValue == this.MaxValue) && (x.MinValue == this.MinValue) && (x.NormalValue == this.NormalValue));
             }
             else
             {
@@ -39,6 +39,26 @@ namespace FTN.Services.NetworkModelService.DataModel.Meas
         }
 
         #region IAccess
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.DISCRETE_MAXVALUE:
+                    property.SetValue(MaxValue);
+                    break;
+                case ModelCode.DISCRETE_MINVALUE:
+                    property.SetValue(MinValue);
+                    break;
+                case ModelCode.DISCRETE_NORMALVALUE:
+                    property.SetValue(NormalValue);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -52,37 +72,18 @@ namespace FTN.Services.NetworkModelService.DataModel.Meas
                     return base.HasProperty(property);
             }
         }
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.DISCRETE_MAXVALUE:
-                    property.SetValue(maxValue);
-                    break;
-                case ModelCode.DISCRETE_MINVALUE:
-                    property.SetValue(minValue);
-                    break;
-                case ModelCode.DISCRETE_NORMALVALUE:
-                    property.SetValue(normalValue);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.DISCRETE_MAXVALUE:
-                    maxValue = property.AsInt();
+                    MaxValue = property.AsInt();
                     break;
                 case ModelCode.DISCRETE_MINVALUE:
-                    minValue = property.AsInt();
+                    MinValue = property.AsInt();
                     break;
                 case ModelCode.DISCRETE_NORMALVALUE:
-                    normalValue = property.AsInt();
+                    NormalValue = property.AsInt();
                     break;
 
                 default:

--- a/Project/NetworkModelService/DataModel/Meas/Measurement.cs
+++ b/Project/NetworkModelService/DataModel/Meas/Measurement.cs
@@ -1,45 +1,65 @@
 ﻿using FTN.Common;
 using FTN.Services.NetworkModelService.DataModel.Core;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Meas
 {
     public class Measurement : IdentifiedObject
     {
+        public int BaseAddress { get; set; }
+
+        public SignalDirection Direction { get; set; }
+
+        public MeasurementType MeasurementType { get; set; }
+
+        public string ObjectMRID { get; set; }
+
+        public long PSR { get; set; } = 0;
+
+        public long Terminals { get; set; } = 0;
+
+        public string TimeStamp { get; set; }
+
         public Measurement(long gID) : base(gID)
         {
         }
+        public Measurement(Measurement measurement) : base(measurement)
+        {
+            BaseAddress = measurement.BaseAddress;
+            Direction = measurement.Direction;
+            MeasurementType = measurement.MeasurementType;
+            ObjectMRID = measurement.ObjectMRID;
+            PSR = measurement.PSR;
+            Terminals = measurement.Terminals;
+            TimeStamp = measurement.TimeStamp;
+        }
 
-        private long terminal = 0;
-        private long pSR = 0;
-        private SignalDirection direction;
-        private MeasurementType measurementType;
-        private int baseAddress;
-        private string objectMRID;
-        private string timeStamp;
 
-        public long Terminals { get => terminal; set => terminal = value; }
-        public long PSR { get => pSR; set => pSR = value; }
-        public SignalDirection Direction { get => direction; set => direction = value; }
-        public MeasurementType MeasurementType { get => measurementType; set => measurementType = value; }
-        public int BaseAddress { get => baseAddress; set => baseAddress = value; }
-        public string ObjectMRID { get => objectMRID; set => objectMRID = value; }
-        public string TimeStamp { get => timeStamp; set => timeStamp = value; }
+        public override void AddReference(ModelCode referenceId, long globalId)
+        {
+            switch (referenceId)
+            {
+                case ModelCode.TERMINAL_MEASUREMENTS:
+                    Terminals = globalId;
+                    break;
+
+                default:
+                    base.AddReference(referenceId, globalId);
+                    break;
+            }
+        }
 
         public override bool Equals(object x)
         {
             if (base.Equals(x))
             {
                 Measurement m = (Measurement)x;
-                return (m.direction == this.direction && m.measurementType == this.measurementType
-                        && m.pSR == this.pSR
-                        && m.objectMRID == this.objectMRID
-                        && m.timeStamp == this.timeStamp
-                        && m.baseAddress == this.baseAddress
-                        && m.terminal == this.terminal);
+                return (m.Direction == this.Direction && m.MeasurementType == this.MeasurementType
+                        && m.PSR == this.PSR
+                        && m.ObjectMRID == this.ObjectMRID
+                        && m.TimeStamp == this.TimeStamp
+                        && m.BaseAddress == this.BaseAddress
+                        && m.Terminals == this.Terminals);
             }
             else
             {
@@ -50,6 +70,55 @@ namespace FTN.Services.NetworkModelService.DataModel.Meas
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.MEASUREMENT_DIRECTION:
+                    property.SetValue((short)Direction);
+                    break;
+                case ModelCode.MEASUREMENT_MEASTYPE:
+                    property.SetValue((short)MeasurementType);
+                    break;
+                case ModelCode.MEASUREMENT_PSR:
+                    property.SetValue(PSR);
+                    break;
+                case ModelCode.MEASUREMENT_TERMINAL:
+                    property.SetValue(Terminals);
+                    break;
+                case ModelCode.MEASUREMENT_BASEADDR:
+                    property.SetValue(BaseAddress);
+                    break;
+                case ModelCode.MEASUREMENT_OBJMRID:
+                    property.SetValue(ObjectMRID);
+                    break;
+                case ModelCode.MEASUREMENT_TIMESTAMP:
+                    property.SetValue(TimeStamp);
+                    break;
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+            if (PSR != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.MEASUREMENT_PSR] = new List<long>
+                {
+                    PSR
+                };
+            }
+            if (Terminals != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.MEASUREMENT_TERMINAL] = new List<long>();
+                references[ModelCode.MEASUREMENT_TERMINAL].Add(Terminals);
+            }
+
+            base.GetReferences(references, refType);
         }
 
         public override bool HasProperty(ModelCode property)
@@ -69,114 +138,14 @@ namespace FTN.Services.NetworkModelService.DataModel.Meas
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.MEASUREMENT_DIRECTION:
-                    property.SetValue((short)direction);
-                    break;
-                case ModelCode.MEASUREMENT_MEASTYPE:
-                    property.SetValue((short)measurementType);
-                    break;
-                case ModelCode.MEASUREMENT_PSR:
-                    property.SetValue(pSR);
-                    break;
-                case ModelCode.MEASUREMENT_TERMINAL:
-                    property.SetValue(terminal);
-                    break;
-                case ModelCode.MEASUREMENT_BASEADDR:
-                    property.SetValue(baseAddress);
-                    break;
-                case ModelCode.MEASUREMENT_OBJMRID:
-                    property.SetValue(objectMRID);
-                    break;
-                case ModelCode.MEASUREMENT_TIMESTAMP:
-                    property.SetValue(timeStamp);
-                    break;
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
-        public override void SetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.MEASUREMENT_DIRECTION:
-                    direction = (SignalDirection)property.AsEnum();
-                    break;
-                case ModelCode.MEASUREMENT_MEASTYPE:
-                    measurementType = (MeasurementType)property.AsEnum();
-                    break;
-                case ModelCode.MEASUREMENT_PSR:
-                    pSR = property.AsReference();
-                    break;
-                case ModelCode.MEASUREMENT_BASEADDR:
-                    baseAddress = property.AsInt();
-                    break;
-                case ModelCode.MEASUREMENT_OBJMRID:
-                    objectMRID = property.AsString();
-                    break;
-                case ModelCode.MEASUREMENT_TIMESTAMP:
-                    timeStamp = property.AsString();
-                    break;
-                default:
-                    base.SetProperty(property);
-                    break;
-            }
-        }
-
-        public override bool IsReferenced
-        {
-            get
-            {
-                return base.IsReferenced;
-            }
-        }
-
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-            if (pSR != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.MEASUREMENT_PSR] = new List<long>
-                {
-                    pSR
-                };
-            }
-            if (terminal != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.MEASUREMENT_TERMINAL] = new List<long>();
-                references[ModelCode.MEASUREMENT_TERMINAL].Add(terminal);
-            }
-
-            base.GetReferences(references, refType);
-        }
-
-        public override void AddReference(ModelCode referenceId, long globalId)
-        {
-            switch (referenceId)
-            {
-                case ModelCode.TERMINAL_MEASUREMENTS:
-                    terminal = globalId;
-                    break;
-
-                default:
-                    base.AddReference(referenceId, globalId);
-                    break;
-            }
-        }
-
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.TERMINAL_MEASUREMENTS:
-                    if (terminal == globalId)
+                    if (Terminals == globalId)
                     {
-                        terminal = 0;
+                        Terminals = 0;
                     }
                     else
                     {
@@ -186,6 +155,34 @@ namespace FTN.Services.NetworkModelService.DataModel.Meas
 
                 default:
                     base.RemoveReference(referenceId, globalId);
+                    break;
+            }
+        }
+
+        public override void SetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.MEASUREMENT_DIRECTION:
+                    Direction = (SignalDirection)property.AsEnum();
+                    break;
+                case ModelCode.MEASUREMENT_MEASTYPE:
+                    MeasurementType = (MeasurementType)property.AsEnum();
+                    break;
+                case ModelCode.MEASUREMENT_PSR:
+                    PSR = property.AsReference();
+                    break;
+                case ModelCode.MEASUREMENT_BASEADDR:
+                    BaseAddress = property.AsInt();
+                    break;
+                case ModelCode.MEASUREMENT_OBJMRID:
+                    ObjectMRID = property.AsString();
+                    break;
+                case ModelCode.MEASUREMENT_TIMESTAMP:
+                    TimeStamp = property.AsString();
+                    break;
+                default:
+                    base.SetProperty(property);
                     break;
             }
         }

--- a/Project/NetworkModelService/DataModel/Topology/ConnectivityNode.cs
+++ b/Project/NetworkModelService/DataModel/Topology/ConnectivityNode.cs
@@ -1,30 +1,30 @@
 ﻿using FTN.Common;
 using FTN.Services.NetworkModelService.DataModel.Core;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Topology
 {
     public class ConnectivityNode : IdentifiedObject
     {
+        public long ConnectivityNodeContainer { get; set; } = 0;
+
+        public List<long> Terminals { get; set; } = new List<long>();
+
         public ConnectivityNode(long gID) : base(gID)
         {
         }
-
-        private long connectivityNodeContainer = 0;
-        private List<long> terminals = new List<long>();
-
-        public long ConnectivityNodeContainer { get => connectivityNodeContainer; set => connectivityNodeContainer = value; }
-        public List<long> Terminals { get => terminals; set => terminals = value; }
+        public ConnectivityNode(ConnectivityNode node) : base(node)
+        {
+            ConnectivityNodeContainer = node.ConnectivityNodeContainer;
+            Terminals = new List<long>(node.Terminals);
+        }
 
         public override bool Equals(object obj)
         {
             if (base.Equals(obj))
             {
                 ConnectivityNode x = (ConnectivityNode)obj;
-                return ((x.connectivityNodeContainer == this.connectivityNodeContainer) && CompareHelper.CompareLists(x.terminals, this.terminals));
+                return ((x.ConnectivityNodeContainer == this.ConnectivityNodeContainer) && CompareHelper.CompareLists(x.Terminals, this.Terminals));
             }
             else
             {
@@ -38,6 +38,22 @@ namespace FTN.Services.NetworkModelService.DataModel.Topology
         }
 
         #region IAccess
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.CONNECTIVITYNODE_CNODECONT:
+                    property.SetValue(ConnectivityNodeContainer);
+                    break;
+                case ModelCode.CONNECTIVITYNODE_TERMINALS:
+                    property.SetValue(Terminals);
+                    break;
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -49,29 +65,12 @@ namespace FTN.Services.NetworkModelService.DataModel.Topology
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.CONNECTIVITYNODE_CNODECONT:
-                    property.SetValue(connectivityNodeContainer);
-                    break;
-                case ModelCode.CONNECTIVITYNODE_TERMINALS:
-                    property.SetValue(terminals);
-                    break;
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.CONNECTIVITYNODE_CNODECONT:
-                    connectivityNodeContainer = property.AsReference();
+                    ConnectivityNodeContainer = property.AsReference();
                     break;
                 default:
                     base.SetProperty(property);
@@ -85,25 +84,8 @@ namespace FTN.Services.NetworkModelService.DataModel.Topology
         {
             get
             {
-                return terminals.Count > 0 || base.IsReferenced;
+                return Terminals.Count > 0 || base.IsReferenced;
             }
-        }
-
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-
-            if (terminals != null && terminals.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.CONNECTIVITYNODE_TERMINALS] = terminals.GetRange(0, terminals.Count);
-            }
-
-            if (connectivityNodeContainer != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.CONNECTIVITYNODE_CNODECONT] = new List<long>();
-                references[ModelCode.CONNECTIVITYNODE_CNODECONT].Add(connectivityNodeContainer);
-            }
-
-            base.GetReferences(references, refType);
         }
 
         public override void AddReference(ModelCode referenceId, long globalId)
@@ -111,7 +93,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Topology
             switch (referenceId)
             {
                 case ModelCode.TERMINAL_CONNNODE:
-                    terminals.Add(globalId);
+                    Terminals.Add(globalId);
                     break;
 
                 default:
@@ -120,15 +102,31 @@ namespace FTN.Services.NetworkModelService.DataModel.Topology
             }
         }
 
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+
+            if (Terminals != null && Terminals.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.CONNECTIVITYNODE_TERMINALS] = Terminals.GetRange(0, Terminals.Count);
+            }
+
+            if (ConnectivityNodeContainer != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.CONNECTIVITYNODE_CNODECONT] = new List<long>();
+                references[ModelCode.CONNECTIVITYNODE_CNODECONT].Add(ConnectivityNodeContainer);
+            }
+
+            base.GetReferences(references, refType);
+        }
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.TERMINAL_CONNNODE:
 
-                    if (terminals.Contains(globalId))
+                    if (Terminals.Contains(globalId))
                     {
-                        terminals.Remove(globalId);
+                        Terminals.Remove(globalId);
                     }
                     else
                     {

--- a/Project/NetworkModelService/DataModel/Wires/Breaker.cs
+++ b/Project/NetworkModelService/DataModel/Wires/Breaker.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace FTN.Services.NetworkModelService.DataModel.Wires
+﻿namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
     public class Breaker : ProtectedSwitch
     {
         public Breaker(long gID) : base(gID)
+        {
+        }
+        public Breaker(Breaker breaker) : base(breaker)
         {
         }
 

--- a/Project/NetworkModelService/DataModel/Wires/Disconnector.cs
+++ b/Project/NetworkModelService/DataModel/Wires/Disconnector.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace FTN.Services.NetworkModelService.DataModel.Wires
+﻿namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
     public class Disconnector : Switch
     {
         public Disconnector(long gID) : base(gID)
+        {
+        }
+        public Disconnector(Disconnector disconnector) : base(disconnector)
         {
         }
 

--- a/Project/NetworkModelService/DataModel/Wires/PowerTransformer.cs
+++ b/Project/NetworkModelService/DataModel/Wires/PowerTransformer.cs
@@ -1,32 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Xml;
-using FTN.Common;
+﻿using FTN.Common;
 using FTN.Services.NetworkModelService.DataModel.Core;
-
+using System.Collections.Generic;
 
 namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
     public class PowerTransformer : Equipment
     {
-        private List<long> transformerWindings = new List<long>();
+        public List<long> TransformerWindings { get; set; } = new List<long>();
 
         public PowerTransformer(long gID) : base(gID)
         {
         }
-
-        public List<long> TransformerWindings { get => transformerWindings; set => transformerWindings = value; }
+        public PowerTransformer(PowerTransformer powerTransformer) : base(powerTransformer)
+        {
+            TransformerWindings = new List<long>(powerTransformer.TransformerWindings);
+        }
 
         public override bool Equals(object obj)
         {
             if (base.Equals(obj))
             {
                 PowerTransformer x = (PowerTransformer)obj;
-                return (CompareHelper.CompareLists(x.transformerWindings, this.transformerWindings));
+                return (CompareHelper.CompareLists(x.TransformerWindings, this.TransformerWindings));
             }
             else
             {
@@ -40,6 +35,19 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
         }
 
         #region IAccess
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.POWERTRANSFORMER_TRWINDINGS:
+                    property.SetValue(TransformerWindings);
+                    break;
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -50,20 +58,6 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.POWERTRANSFORMER_TRWINDINGS:
-                    property.SetValue(transformerWindings);
-                    break;
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             base.SetProperty(property);
@@ -75,18 +69,8 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
         {
             get
             {
-                return transformerWindings.Count > 0 || base.IsReferenced;
+                return TransformerWindings.Count > 0 || base.IsReferenced;
             }
-        }
-
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-            if (transformerWindings != null && transformerWindings.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.POWERTRANSFORMER_TRWINDINGS] = transformerWindings.GetRange(0, transformerWindings.Count);
-            }
-
-            base.GetReferences(references, refType);
         }
 
         public override void AddReference(ModelCode referenceId, long globalId)
@@ -94,7 +78,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
             switch (referenceId)
             {
                 case ModelCode.TRANSFORMERWINDING_POWERTR:
-                    transformerWindings.Add(globalId);
+                    TransformerWindings.Add(globalId);
                     break;
 
                 default:
@@ -103,15 +87,24 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
             }
         }
 
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+            if (TransformerWindings != null && TransformerWindings.Count != 0 && (refType == TypeOfReference.Target || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.POWERTRANSFORMER_TRWINDINGS] = TransformerWindings.GetRange(0, TransformerWindings.Count);
+            }
+
+            base.GetReferences(references, refType);
+        }
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.TRANSFORMERWINDING_POWERTR:
 
-                    if (transformerWindings.Contains(globalId))
+                    if (TransformerWindings.Contains(globalId))
                     {
-                        transformerWindings.Remove(globalId);
+                        TransformerWindings.Remove(globalId);
                     }
                     else
                     {

--- a/Project/NetworkModelService/DataModel/Wires/ProtectedSwitch.cs
+++ b/Project/NetworkModelService/DataModel/Wires/ProtectedSwitch.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace FTN.Services.NetworkModelService.DataModel.Wires
+﻿namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
     public class ProtectedSwitch : Switch
     {
         public ProtectedSwitch(long gID) : base(gID)
         {
+        }
+        public ProtectedSwitch(ProtectedSwitch protectedSwitch) : base(protectedSwitch)
+        {
+
         }
 
         public override bool Equals(object x)

--- a/Project/NetworkModelService/DataModel/Wires/RatioTapChanger.cs
+++ b/Project/NetworkModelService/DataModel/Wires/RatioTapChanger.cs
@@ -1,28 +1,27 @@
 ﻿using FTN.Common;
 using FTN.Services.NetworkModelService.DataModel.Core;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
     public class RatioTapChanger : TapChanger
     {
-        private long transformerWinding = 0;
+        public long TransformerWinding { get; set; } = 0;
 
         public RatioTapChanger(long gID) : base(gID)
         {
         }
-
-        public long TransformerWinding { get => transformerWinding; set => transformerWinding = value; }
+        public RatioTapChanger(RatioTapChanger tapChanger) : base(tapChanger)
+        {
+            TransformerWinding = tapChanger.TransformerWinding;
+        }
 
         public override bool Equals(object obj)
         {
             if (base.Equals(obj))
             {
                 RatioTapChanger x = (RatioTapChanger)obj;
-                return ((x.transformerWinding == this.transformerWinding));
+                return ((x.TransformerWinding == this.TransformerWinding));
             }
             else
             {
@@ -36,6 +35,19 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
         }
 
         #region IAccess
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.RATIOTAPCHANGER_TRWINDING:
+                    property.SetValue(TransformerWinding);
+                    break;
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -46,26 +58,12 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.RATIOTAPCHANGER_TRWINDING:
-                    property.SetValue(transformerWinding);
-                    break;
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.RATIOTAPCHANGER_TRWINDING:
-                    transformerWinding = property.AsReference();
+                    TransformerWinding = property.AsReference();
                     break;
                 default:
                     base.SetProperty(property);
@@ -78,10 +76,10 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
 
         public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
         {
-            if (transformerWinding != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            if (TransformerWinding != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
             {
                 references[ModelCode.RATIOTAPCHANGER_TRWINDING] = new List<long>();
-                references[ModelCode.RATIOTAPCHANGER_TRWINDING].Add(transformerWinding);
+                references[ModelCode.RATIOTAPCHANGER_TRWINDING].Add(TransformerWinding);
             }
 
             base.GetReferences(references, refType);

--- a/Project/NetworkModelService/DataModel/Wires/RegulatingCondEq.cs
+++ b/Project/NetworkModelService/DataModel/Wires/RegulatingCondEq.cs
@@ -1,8 +1,4 @@
 ﻿using FTN.Services.NetworkModelService.DataModel.Core;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
@@ -10,6 +6,10 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
     {
         public RegulatingCondEq(long gID) : base(gID)
         {
+        }
+        public RegulatingCondEq(RegulatingCondEq equipment) : base(equipment)
+        {
+
         }
 
         public override bool Equals(object x)

--- a/Project/NetworkModelService/DataModel/Wires/Switch.cs
+++ b/Project/NetworkModelService/DataModel/Wires/Switch.cs
@@ -1,18 +1,18 @@
 ﻿using FTN.Common;
 using FTN.Services.NetworkModelService.DataModel.Core;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
     public class Switch : ConductingEquipment
     {
-        private int manipulationCount;
-        public int ManipulationCount { get => manipulationCount; set => manipulationCount = value; }
+        public int ManipulationCount { get; set; }
+
         public Switch(long gID) : base(gID)
         {
+        }
+        public Switch(Switch @switch) : base(@switch)
+        {
+            ManipulationCount = @switch.ManipulationCount;
         }
 
         public override bool Equals(object x)
@@ -20,7 +20,7 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
             if (base.Equals(x))
             {
                 Switch s = (Switch)x;
-                return this.manipulationCount == s.ManipulationCount ? true : false;
+                return this.ManipulationCount == s.ManipulationCount ? true : false;
             }
             else
             {
@@ -35,6 +35,20 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
 
         #region IAccess implementation	
 
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.SWITCH_MANIPULATIONCOUNT:
+                    property.SetValue(ManipulationCount);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -46,27 +60,12 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.SWITCH_MANIPULATIONCOUNT:
-                    property.SetValue(manipulationCount);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.SUBSTATION_CAPACITY:
-                    manipulationCount = property.AsInt();
+                    ManipulationCount = property.AsInt();
                     break;
                 default:
                     base.SetProperty(property);

--- a/Project/NetworkModelService/DataModel/Wires/TapChanger.cs
+++ b/Project/NetworkModelService/DataModel/Wires/TapChanger.cs
@@ -1,32 +1,32 @@
 ﻿using FTN.Common;
 using FTN.Services.NetworkModelService.DataModel.Core;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
     public class TapChanger : PowerSystemResource
     {
-        private int highStep;
-        private int lowStep;
-        private int normalStep;
+        public int HighStep { get; set; }
+
+        public int LowStep { get; set; }
+
+        public int NormalStep { get; set; }
 
         public TapChanger(long gID) : base(gID)
         {
         }
-
-        public int HighStep { get => highStep; set => highStep = value; }
-        public int LowStep { get => lowStep; set => lowStep = value; }
-        public int NormalStep { get => normalStep; set => normalStep = value; }
+        public TapChanger(TapChanger tapChanger) : base(tapChanger)
+        {
+            HighStep = tapChanger.HighStep;
+            LowStep = tapChanger.LowStep;
+            NormalStep = tapChanger.NormalStep;
+        }
 
         public override bool Equals(object obj)
         {
             if (base.Equals(obj))
             {
                 TapChanger x = (TapChanger)obj;
-                return ((x.highStep == this.highStep) && (x.lowStep == this.lowStep) && (x.normalStep == this.normalStep));
+                return ((x.HighStep == this.HighStep) && (x.LowStep == this.LowStep) && (x.NormalStep == this.NormalStep));
             }
             else
             {
@@ -40,6 +40,26 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
         }
 
         #region IAccess
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.TAPCHANGER_HIGHSTEP:
+                    property.SetValue(HighStep);
+                    break;
+                case ModelCode.TAPCHANGER_LOWSTEP:
+                    property.SetValue(LowStep);
+                    break;
+                case ModelCode.TAPCHANGER_NORMALSTEP:
+                    property.SetValue(NormalStep);
+                    break;
+
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -53,37 +73,18 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
                     return base.HasProperty(property);
             }
         }
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.TAPCHANGER_HIGHSTEP:
-                    property.SetValue(highStep);
-                    break;
-                case ModelCode.TAPCHANGER_LOWSTEP:
-                    property.SetValue(lowStep);
-                    break;
-                case ModelCode.TAPCHANGER_NORMALSTEP:
-                    property.SetValue(normalStep);
-                    break;
-
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.TAPCHANGER_HIGHSTEP:
-                    highStep = property.AsInt();
+                    HighStep = property.AsInt();
                     break;
                 case ModelCode.TAPCHANGER_LOWSTEP:
-                    lowStep = property.AsInt();
+                    LowStep = property.AsInt();
                     break;
                 case ModelCode.TAPCHANGER_NORMALSTEP:
-                    normalStep = property.AsInt();
+                    NormalStep = property.AsInt();
                     break;
 
                 default:

--- a/Project/NetworkModelService/DataModel/Wires/TransformerWinding.cs
+++ b/Project/NetworkModelService/DataModel/Wires/TransformerWinding.cs
@@ -1,33 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Xml;
-using FTN.Common;
+﻿using FTN.Common;
 using FTN.Services.NetworkModelService.DataModel.Core;
+using System.Collections.Generic;
 
 namespace FTN.Services.NetworkModelService.DataModel.Wires
 {
     public class TransformerWinding : ConductingEquipment
     {
-        private long powerTransformer = 0;
-        private long ratioTapChanger = 0;
+        public long PowerTransformer { get; set; } = 0;
+
+        public long RatioTapChanger { get; set; } = 0;
 
         public TransformerWinding(long gID) : base(gID)
         {
         }
-
-        public long PowerTransformer { get => powerTransformer; set => powerTransformer = value; }
-        public long RatioTapChanger { get => ratioTapChanger; set => ratioTapChanger = value; }
+        public TransformerWinding(TransformerWinding transformerWinding) : base(transformerWinding)
+        {
+            PowerTransformer = transformerWinding.PowerTransformer;
+            RatioTapChanger = transformerWinding.RatioTapChanger;
+        }
 
         public override bool Equals(object obj)
         {
             if (base.Equals(obj))
             {
                 TransformerWinding x = (TransformerWinding)obj;
-                return ((x.powerTransformer == this.powerTransformer) && (x.ratioTapChanger == this.ratioTapChanger));
+                return ((x.PowerTransformer == this.PowerTransformer) && (x.RatioTapChanger == this.RatioTapChanger));
             }
             else
             {
@@ -41,6 +38,22 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
         }
 
         #region IAccess
+        public override void GetProperty(Property property)
+        {
+            switch (property.Id)
+            {
+                case ModelCode.TRANSFORMERWINDING_POWERTR:
+                    property.SetValue(PowerTransformer);
+                    break;
+                case ModelCode.TRANSFORMERWINDING_RATIOTC:
+                    property.SetValue(RatioTapChanger);
+                    break;
+                default:
+                    base.GetProperty(property);
+                    break;
+            }
+        }
+
         public override bool HasProperty(ModelCode property)
         {
             switch (property)
@@ -52,32 +65,15 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
                     return base.HasProperty(property);
             }
         }
-
-        public override void GetProperty(Property property)
-        {
-            switch (property.Id)
-            {
-                case ModelCode.TRANSFORMERWINDING_POWERTR:
-                    property.SetValue(powerTransformer);
-                    break;
-                case ModelCode.TRANSFORMERWINDING_RATIOTC:
-                    property.SetValue(ratioTapChanger);
-                    break;
-                default:
-                    base.GetProperty(property);
-                    break;
-            }
-        }
-
         public override void SetProperty(Property property)
         {
             switch (property.Id)
             {
                 case ModelCode.TRANSFORMERWINDING_POWERTR:
-                    powerTransformer = property.AsReference();
+                    PowerTransformer = property.AsReference();
                     break;
                 case ModelCode.TRANSFORMERWINDING_RATIOTC:
-                    ratioTapChanger = property.AsReference();
+                    RatioTapChanger = property.AsReference();
                     break;
                 default:
                     base.SetProperty(property);
@@ -87,29 +83,12 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
         #endregion
 
         #region IReference
-        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
-        {
-            if (powerTransformer != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.TRANSFORMERWINDING_POWERTR] = new List<long>();
-                references[ModelCode.TRANSFORMERWINDING_POWERTR].Add(powerTransformer);
-            }
-
-            if (ratioTapChanger != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
-            {
-                references[ModelCode.TRANSFORMERWINDING_RATIOTC] = new List<long>();
-                references[ModelCode.TRANSFORMERWINDING_RATIOTC].Add(ratioTapChanger);
-            }
-
-            base.GetReferences(references, refType);
-        }
-
         public override void AddReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.RATIOTAPCHANGER_TRWINDING:
-                    ratioTapChanger = globalId;
+                    RatioTapChanger = globalId;
                     break;
 
                 default:
@@ -118,15 +97,31 @@ namespace FTN.Services.NetworkModelService.DataModel.Wires
             }
         }
 
+        public override void GetReferences(Dictionary<ModelCode, List<long>> references, TypeOfReference refType)
+        {
+            if (PowerTransformer != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.TRANSFORMERWINDING_POWERTR] = new List<long>();
+                references[ModelCode.TRANSFORMERWINDING_POWERTR].Add(PowerTransformer);
+            }
+
+            if (RatioTapChanger != 0 && (refType == TypeOfReference.Reference || refType == TypeOfReference.Both))
+            {
+                references[ModelCode.TRANSFORMERWINDING_RATIOTC] = new List<long>();
+                references[ModelCode.TRANSFORMERWINDING_RATIOTC].Add(RatioTapChanger);
+            }
+
+            base.GetReferences(references, refType);
+        }
         public override void RemoveReference(ModelCode referenceId, long globalId)
         {
             switch (referenceId)
             {
                 case ModelCode.RATIOTAPCHANGER_TRWINDING:
 
-                    if (ratioTapChanger == globalId)
+                    if (RatioTapChanger == globalId)
                     {
-                        ratioTapChanger = 0;
+                        RatioTapChanger = 0;
                     }
                     else
                     {


### PR DESCRIPTION
## Summary

Dodao sam deep copy implementaciju putem konstruktora kopije.

## Notes

String sam uradio na `x = y` način jer, za razliku od C/C++ gde je "string" zapravo pokazivač na niz karaktera, u C# je string immutable, što znači da bilo kakva promena/modifikacija stringa izaziva alociranje nove memorije i vraćanja nove reference na tu novu memoriju. Drugim rečima sama prednost uvođenja stringa kao immutable objekta nam obezbeđuje baš to da izbegnemo (često sporo) kopiranje (kao npr. strcpy) koje je obavezno u C/C++ npr. 

Ukoliko primetite ipak neki problem javite mi pa ću napisati extension metodu za string i ažurirati konstruktore 😃 

Što se tiče lista rešenje sa `new List<T>(item.list)` je dovoljno iz razloga što se radi o primitivnim tipovima. Ukoliko se odlučite da proširite neku od ovih klasa sa nekim custom tipom onda bi bilo potrebno uraditi nešto poput `new List<T>(item.list.Select(listItem=>new T(listItem)))`

> Isto sam ipak promenio ove propertije u auto-property jer je previše nepregledno bilo onako (mogao sam lako da propustim neku promenljivu u konstruktoru pa posle da nas boli glava prilikom debug-a)
