### PR TITLE
Added NServiceBus to NDS with demo commands, events and handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# NServiceBus
+.learningtransport
+
 # User-specific files
 *.rsuser
 *.suo

--- a/Project/Core.Common/Core.Common.csproj
+++ b/Project/Core.Common/Core.Common.csproj
@@ -34,8 +34,14 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NServiceBus.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.7.4.4\lib\net452\NServiceBus.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -45,6 +51,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceBus\Commands\DemoCommand.cs" />
+    <Compile Include="ServiceBus\EndpointNames.cs" />
+    <Compile Include="ServiceBus\Events\DemoEvent.cs" />
     <Compile Include="WeatherApi\Data\Day.cs" />
     <Compile Include="WeatherApi\Data\Forecast.cs" />
     <Compile Include="WeatherApi\Data\ForecastDay.cs" />
@@ -56,5 +65,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\NServiceBus.7.4.4\analyzers\dotnet\cs\NServiceBus.Core.Analyzer.dll" />
+  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Project/Core.Common/ServiceBus/Commands/DemoCommand.cs
+++ b/Project/Core.Common/ServiceBus/Commands/DemoCommand.cs
@@ -1,0 +1,15 @@
+﻿namespace Core.Common.ServiceBus.Commands
+{
+    /**
+     * Example Command class (feel free to delete it)
+     * 
+     * NOTE: Take care when using auto-complete, ICommand in this case is from NServiceBus, and NOT System.Windows.Input (don't mix these two)
+     */
+    public class DemoCommand : NServiceBus.ICommand
+    {
+        /* 
+         * Add any properties you want just like you would in any other DTO class (ex. WCF, ASP.NET...)
+         */
+        public string DemoProperty { get; set; }
+    }
+}

--- a/Project/Core.Common/ServiceBus/EndpointNames.cs
+++ b/Project/Core.Common/ServiceBus/EndpointNames.cs
@@ -1,0 +1,12 @@
+﻿namespace Core.Common.ServiceBus
+{
+    /// <summary>
+    /// Collection of endpoint names used in EventBus
+    /// </summary>
+    public static class EndpointNames
+    {
+        public const string SCADA = "SCADA";
+        public const string GUI = "GUI";
+        public const string NMS = "NMS";
+    }
+}

--- a/Project/Core.Common/ServiceBus/Events/DemoEvent.cs
+++ b/Project/Core.Common/ServiceBus/Events/DemoEvent.cs
@@ -1,0 +1,15 @@
+﻿using NServiceBus;
+
+namespace Core.Common.ServiceBus.Events
+{
+    /**
+     * Example event class (feel free to delete it)
+     * **/
+    public class DemoEvent : IEvent
+    {
+        /* 
+         * Add any properties you want just like you would in any other DTO class (ex. WCF, ASP.NET...)
+         */
+        public string DemoProperty { get; set; }
+    }
+}

--- a/Project/TESTSKADA/NDS.csproj
+++ b/Project/TESTSKADA/NDS.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B065B3B6-D3E0-4C60-A4F9-30F6087C733C}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>TESTSKADA</RootNamespace>
+    <RootNamespace>NDS</RootNamespace>
     <AssemblyName>TESTSKADA</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -33,8 +33,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NServiceBus.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.7.4.4\lib\net452\NServiceBus.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -45,11 +51,18 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServiceBus\Handlers\DemoHandler.cs" />
+    <Compile Include="ServiceBus\ServiceBusStartup.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Core.Common\Core.Common.csproj">
+      <Project>{83773854-5d2a-458a-a6e5-299dd7e6240a}</Project>
+      <Name>Core.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SCADA.Common\SCADA.Common.csproj">
       <Project>{6e79fca4-42e3-4d2f-b4a3-28e691bf04c3}</Project>
       <Name>SCADA.Common</Name>
@@ -62,6 +75,9 @@
       <Project>{f5d28aa0-b5f6-4c6a-867d-2d1187464a80}</Project>
       <Name>TMContracts</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\NServiceBus.7.4.4\analyzers\dotnet\cs\NServiceBus.Core.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Project/TESTSKADA/Program.cs
+++ b/Project/TESTSKADA/Program.cs
@@ -1,25 +1,38 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using SCADA.Common.Connection;
-using SCADA.Common.DataModel;
-using SCADA.Common.Messaging;
-using SCADA.Common.Messaging.Messages;
-using SCADA.Common.Messaging.Parameters;
+using Core.Common.ServiceBus.Events;
+using NDS.ServiceBus;
+using NServiceBus;
+using NServiceBus.Logging;
 using SCADATransaction;
-using TMContracts;
 
 namespace NDS
 {
-	class Program
+    class Program
 	{
 		static void Main(string[] args)
 		{
+            AsyncMain().GetAwaiter().GetResult();
+        }
+
+        static readonly ILog log = LogManager.GetLogger<Program>();
+
+        private static async Task AsyncMain()
+        {
             Console.Title = "NetworkDynamicService";
-            Console.WriteLine("SCADA started working..");
+            
+            log.Info("SCADA started working..");
+
+            var endpoint = await ServiceBusStartup.StartInstance()
+                .ConfigureAwait(false);
+
+            // Command example: 
+            // await endpoint.Send(new DemoCommand { DemoProperty = "Do something!" });
+            // NOTE: Don't forget to add routes for each command in ServiceBusStartup! (you don't need to do this for events)
+
+            // Event example:
+            await endpoint.Publish(new DemoEvent { DemoProperty = "Something happened!" })
+                .ConfigureAwait(false);
 
             SCADAServer scada = new SCADAServer();
             scada.OpenModel();

--- a/Project/TESTSKADA/ServiceBus/Handlers/DemoHandler.cs
+++ b/Project/TESTSKADA/ServiceBus/Handlers/DemoHandler.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Core.Common.ServiceBus.Events;
+using NServiceBus;
+using NServiceBus.Logging;
+
+namespace NDS.ServiceBus.Handlers
+{
+    public class DemoHandler : IHandleMessages<DemoEvent>
+    {
+        private static readonly ILog log = LogManager.GetLogger<DemoHandler>();
+
+        public Task Handle(DemoEvent message, IMessageHandlerContext context)
+        {
+            log.Info($"Received DemoEvent, DemoProperty = {message.DemoProperty}");
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Project/TESTSKADA/ServiceBus/ServiceBusStartup.cs
+++ b/Project/TESTSKADA/ServiceBus/ServiceBusStartup.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using Core.Common.ServiceBus;
+using Core.Common.ServiceBus.Commands;
+using NServiceBus;
+
+namespace NDS.ServiceBus
+{
+    /// <summary>
+    /// Helper class for initializing SCADA endpoint instance
+    /// </summary>
+    internal static class ServiceBusStartup
+    {
+        /// <summary>
+        /// Creates and starts new instance for Scada endpoint
+        /// </summary>
+        /// <param name="endpointName"></param>
+        public static Task<IEndpointInstance> StartInstance(string endpointName = EndpointNames.SCADA)
+        {
+            var endpointConfiguration = GetConfiguration(endpointName);
+
+            /* Start the endpoint */
+            return Endpoint.Start(endpointConfiguration);
+        }
+
+        private static EndpointConfiguration GetConfiguration(string endpointName)
+        {
+            var endpointConfiguration = new EndpointConfiguration(endpointName);
+
+            var transport = endpointConfiguration.UseTransport<LearningTransport>();
+
+            var routing = transport.Routing();
+
+            // Route example: 
+            // routing.RouteToEndpoint(typeof(DemoCommand), EndpointNames.GUI);
+            // Note: you only need to define routes for commands (no need to do so for events!)
+
+            return endpointConfiguration;
+        }
+    }
+}

--- a/Project/TESTSKADA/packages.config
+++ b/Project/TESTSKADA/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="NServiceBus" version="7.4.4" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
# Summary

Odabran NServiceBus za implementaciju PubSub modela.

Ovaj PR (pull request) sadrži Demo komande, događaja, i handlera za događaje. 

# Notes

Ono što treba napomenuti jeste razlika između događaja i komandi što je odlično objašnjeno na sledećem linku (5 minuta čitanja) - https://docs.particular.net/tutorials/nservicebus-step-by-step/4-publishing-events/

Ključno iz teksta: 
Događaji - šalju se svima (ili nikome)
Komande - šalju se jednom servisu

**Sa obzirom da se komande šalju samo jednom servisu potrebno je specifirati kojem**, u ove svrhe sam, radi preglednijeg/urednijeg (samim tim i lakšim za održavanje) rešenja izdvojio konfigurisanje u odvojenu klasu (ServiceBusStartup) - bilo bi poželjno da ovu klasu ima svaki servis koji želi da koristi ServiceBus radi konzistentnosti

Naknadno ću i objaviti Wiki gde bi dokumentovao ključne stvari vezane za NServiceBus da bi mogli da se podsetimo u svakom momentu :)